### PR TITLE
Increase precision in dec_tree_generator.py

### DIFF
--- a/tools/decision_tree_generator/python/dec_tree_generator.py
+++ b/tools/decision_tree_generator/python/dec_tree_generator.py
@@ -153,7 +153,7 @@ def generateDecisionTree(arff_filename, dectree_filename):
     print("Accuracy:", dectree_accuracy)
 
     dot_tree = tree.export_graphviz(clf, out_file=None, class_names=clf.classes_, label="none", impurity=False,
-                                    feature_names=feature_cols)
+                                    feature_names=feature_cols, precision=10) # lower precision cuts off float values
 
     dt_file = open(dectree_filename, "w")
     n_nodes, n_leaves = printTree(dot_tree, dt_file)


### PR DESCRIPTION
With this change the precision is increased from 3 (the default) to 10.
Doing this allows generating decision trees for numbers with several
decimal places which otherwise get rounded and information gets lost.
This should also better match the general handling of inputs within
the application.