### PR TITLE
Fixed incorrect parsing indices in formatTree

### DIFF
--- a/tools/decision_tree_generator/python/Decision tree generator.ipynb
+++ b/tools/decision_tree_generator/python/Decision tree generator.ipynb
@@ -123,7 +123,7 @@
     "        new_tree.append(line)\n",
     "\n",
     "    # Print in Weka format\n",
-    "    n_nodes, n_leaves = formatTree(new_tree[2:-1], 0, dt_file)\n",
+    "    n_nodes, n_leaves = formatTree(new_tree[3:-1], 0, dt_file)\n",
     "\n",
     "    print('\\nNumber of Leaves  : \\t', n_leaves, file=dt_file)\n",
     "    print('\\nSize of the Tree : \\t', n_nodes, file=dt_file)\n",

--- a/tools/decision_tree_generator/python/dec_tree_generator.py
+++ b/tools/decision_tree_generator/python/dec_tree_generator.py
@@ -115,7 +115,7 @@ def printTree(dot_tree, dt_file):
         new_tree.append(line)
 
     # Print in Weka format
-    n_nodes, n_leaves = formatTree(new_tree[2:-1], 0, dt_file)
+    n_nodes, n_leaves = formatTree(new_tree[3:-1], 0, dt_file)
 
     print('\nNumber of Leaves  : \t', n_leaves, file=dt_file)
     print('\nSize of the Tree : \t', n_nodes, file=dt_file)

--- a/tools/mlc_python_script/Script/decision_tree_generator.py
+++ b/tools/mlc_python_script/Script/decision_tree_generator.py
@@ -116,7 +116,7 @@ def printTree(dot_tree, dt_file):
         new_tree.append(line)
 
     # Print in Weka format
-    size_tree, n_leaves = formatTree(new_tree[2:-1], 0, dt_file)
+    size_tree, n_leaves = formatTree(new_tree[3:-1], 0, dt_file)
 
     print('\nNumber of Leaves  : \t', n_leaves, file=dt_file)
     print('\nSize of the Tree : \t', size_tree, file=dt_file)


### PR DESCRIPTION
Changed indices used for calls to formatTree method.

Errors were being thrown due to formatting (font) line being incorrectly read during parsing of DOT tree format.
This change allows example notebooks and scripts using decision tree generator to run correctly again.