### PR TITLE
Fixed incorrect parsing indices in formatTree

### DIFF
--- a/tools/decision_tree_generator/python/Decision tree generator.ipynb
+++ b/tools/decision_tree_generator/python/Decision tree generator.ipynb
@@ -116,14 +116,16 @@
     "    for line in dot_tree.split(\"\\n\"):\n",
     "        r = re.search(\"[0-9]+\\\\\\\\n\\[([0-9]+[,]?[ ]?)+\\]\\\\\\\\n\", line)\n",
     "        s = re.search(\"\\[labeldistance=[0-9]+\\.?[0-9]*, labelangle=-?[0-9]+, headlabel=\\\"(False|True)\\\"\\]\", line)\n",
+    "        t = re.search(\"(\\d+\\s*\\[.*)|(\\d\\s*->\\s*\\d)|(.*}.*)\", line)\n",
     "        if (r != None):\n",
     "            line = line[:r.start()] + line[r.end():]\n",
     "        if (s != None):\n",
     "            line = line[:s.start()] + line[s.end():]\n",
-    "        new_tree.append(line)\n",
+    "        if (t != None):\n",
+    "            new_tree.append(line)\n",
     "\n",
     "    # Print in Weka format\n",
-    "    n_nodes, n_leaves = formatTree(new_tree[3:-1], 0, dt_file)\n",
+    "    n_nodes, n_leaves = formatTree(new_tree[:-1], 0, dt_file)\n",
     "\n",
     "    print('\\nNumber of Leaves  : \\t', n_leaves, file=dt_file)\n",
     "    print('\\nSize of the Tree : \\t', n_nodes, file=dt_file)\n",
@@ -224,7 +226,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.5 64-bit (windows store)",
    "language": "python",
    "name": "python3"
   },
@@ -238,7 +240,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31751ba59db5c716e82f2069fa6de2d63d703d6747f3517ddc9aa229677c60a7"
+   }
   }
  },
  "nbformat": 4,

--- a/tools/decision_tree_generator/python/Decision tree generator.ipynb
+++ b/tools/decision_tree_generator/python/Decision tree generator.ipynb
@@ -123,7 +123,7 @@
     "        new_tree.append(line)\n",
     "\n",
     "    # Print in Weka format\n",
-    "    n_nodes, n_leaves = formatTree(new_tree[2:-1], 0, dt_file)\n",
+    "    n_nodes, n_leaves = formatTree(new_tree[3:-1], 0, dt_file)\n",
     "\n",
     "    print('\\nNumber of Leaves  : \\t', n_leaves, file=dt_file)\n",
     "    print('\\nSize of the Tree : \\t', n_nodes, file=dt_file)\n",

--- a/tools/decision_tree_generator/python/dec_tree_generator.py
+++ b/tools/decision_tree_generator/python/dec_tree_generator.py
@@ -108,14 +108,16 @@ def printTree(dot_tree, dt_file):
     for line in dot_tree.split("\n"):
         r = re.search("[0-9]+\\\\n\[([0-9]+[,]?[ ]?)+\]\\\\n", line)
         s = re.search("\[labeldistance=[0-9]+\.?[0-9]*, labelangle=-?[0-9]+, headlabel=\"(False|True)\"\]", line)
+        t = re.search("(\d+\s*\[.*)|(\d\s*->\s*\d)|(.*}.*)", line)
         if (r != None):
             line = line[:r.start()] + line[r.end():]
         if (s != None):
             line = line[:s.start()] + line[s.end():]
-        new_tree.append(line)
+        if (t != None):
+            new_tree.append(line)
 
     # Print in Weka format
-    n_nodes, n_leaves = formatTree(new_tree[3:-1], 0, dt_file)
+    n_nodes, n_leaves = formatTree(new_tree[:-1], 0, dt_file)
 
     print('\nNumber of Leaves  : \t', n_leaves, file=dt_file)
     print('\nSize of the Tree : \t', n_nodes, file=dt_file)

--- a/tools/decision_tree_generator/python/dec_tree_generator.py
+++ b/tools/decision_tree_generator/python/dec_tree_generator.py
@@ -115,7 +115,7 @@ def printTree(dot_tree, dt_file):
         new_tree.append(line)
 
     # Print in Weka format
-    n_nodes, n_leaves = formatTree(new_tree[2:-1], 0, dt_file)
+    n_nodes, n_leaves = formatTree(new_tree[3:-1], 0, dt_file)
 
     print('\nNumber of Leaves  : \t', n_leaves, file=dt_file)
     print('\nSize of the Tree : \t', n_nodes, file=dt_file)

--- a/tools/mlc_python_script/Script/decision_tree_generator.py
+++ b/tools/mlc_python_script/Script/decision_tree_generator.py
@@ -116,7 +116,7 @@ def printTree(dot_tree, dt_file):
         new_tree.append(line)
 
     # Print in Weka format
-    size_tree, n_leaves = formatTree(new_tree[2:-1], 0, dt_file)
+    size_tree, n_leaves = formatTree(new_tree[3:-1], 0, dt_file)
 
     print('\nNumber of Leaves  : \t', n_leaves, file=dt_file)
     print('\nSize of the Tree : \t', size_tree, file=dt_file)

--- a/tools/mlc_python_script/Script/decision_tree_generator.py
+++ b/tools/mlc_python_script/Script/decision_tree_generator.py
@@ -109,14 +109,16 @@ def printTree(dot_tree, dt_file):
     for line in dot_tree.split("\n"):
         r = re.search("[0-9]+\\\\n\[([0-9]+[,]?[ ]?)+\]\\\\n", line)
         s = re.search("\[labeldistance=[0-9]+\.?[0-9]*, labelangle=-?[0-9]+, headlabel=\"(False|True)\"\]", line)
+        t = re.search("(\d+\s*\[.*)|(\d\s*->\s*\d)|(.*}.*)", line)
         if (r != None):
             line = line[:r.start()] + line[r.end():]
         if (s != None):
             line = line[:s.start()] + line[s.end():]
-        new_tree.append(line)
+        if (t != None):
+            new_tree.append(line)
 
     # Print in Weka format
-    size_tree, n_leaves = formatTree(new_tree[3:-1], 0, dt_file)
+    size_tree, n_leaves = formatTree(new_tree[:-1], 0, dt_file)
 
     print('\nNumber of Leaves  : \t', n_leaves, file=dt_file)
     print('\nSize of the Tree : \t', size_tree, file=dt_file)


### PR DESCRIPTION
Changed indices used for calls to formatTree method.

Errors were being thrown due to formatting (font) line being incorrectly read during parsing of DOT tree format.
This change allows example notebooks and scripts using decision tree generator to run correctly again.